### PR TITLE
Make --target-version optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,13 +90,21 @@ Usage
 =====
 
 ``djade`` is a commandline tool that rewrites files in place.
-Pass your Django version as ``<major>.<minor>`` to the ``--target-version`` flag and a list of template files.
-Djade will format and update the templates as necessary:
+Pass a list of template files to format them:
 
 .. code-block:: console
 
-    $ djade --target-version 5.1 templates/index.html
-    Rewriting templates/index.html
+    $ djade --target-version 5.1 templates/eggs/*.html
+    Rewriting templates/eggs/dodo.html
+    Rewriting templates/eggs/ostrich.html
+
+Djade can also upgrade some old template syntax.
+Add the ``--target-version`` option with your Django version as ``<major>.<minor>`` to enable applicable fixers:
+
+.. code-block:: console
+
+    $ djade --target-version 5.1 templates/eggs/*.html
+    Rewriting templates/eggs/quail.html
 
 Djade does not have any ability to recurse through directories.
 Use the pre-commit integration, globbing, or another technique for applying to many files.
@@ -124,10 +132,8 @@ Options
 ``--target-version``
 --------------------
 
-The version of Django to target, in the format ``<major>.<minor>``.
-Djade enables its fixers for versions up to and including the target version.
-
-This option defaults to 4.2, the oldest supported version when this project was created.
+Optional: the version of Django to target, in the format ``<major>.<minor>``.
+If provided, Djade enables its fixers for versions up to and including the target version.
 See the list of available versions with ``djade  --help``.
 
 Rules

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,29 +13,11 @@ pub struct Args {
 
     #[arg(
         long,
-        default_value = "4.2",
-        value_parser = parse_version,
+        default_value = None,
+        value_parser = ["2.1", "2.2", "3.0", "3.1", "3.2", "4.1", "4.2", "5.0", "5.1"],
         help = "The version of Django to target.",
     )]
-    pub target_version: (u8, u8),
-}
-
-fn parse_version(s: &str) -> Result<(u8, u8), String> {
-    match s {
-        "2.1" => Ok((2, 1)),
-        "2.2" => Ok((2, 2)),
-        "3.0" => Ok((3, 0)),
-        "3.1" => Ok((3, 1)),
-        "3.2" => Ok((3, 2)),
-        "4.1" => Ok((4, 1)),
-        "4.2" => Ok((4, 2)),
-        "5.0" => Ok((5, 0)),
-        "5.1" => Ok((5, 1)),
-        _ => Err(format!(
-            "Invalid version: {}. Allowed versions are 4.2, 5.0, 5.1.",
-            s
-        )),
-    }
+    pub target_version: Option<String>,
 }
 
 #[cfg(test)]
@@ -65,12 +47,12 @@ mod tests {
     #[test]
     fn test_target_version_default() {
         let args = Args::parse_from(["djade", "file1.html"]);
-        assert_eq!(args.target_version, (4, 2));
+        assert_eq!(args.target_version, None);
     }
 
     #[test]
     fn test_target_version_set() {
         let args = Args::parse_from(["djade", "--target-version", "5.1", "file1.html"]);
-        assert_eq!(args.target_version, (5, 1));
+        assert_eq!(args.target_version, Some(String::from("5.1")));
     }
 }


### PR DESCRIPTION
This makes the tool easier to get started with and maybe use with other templates like Jinja ones (which won't be officially supported, though).