### PR TITLE
Adjust spacing of top-level tags after {% extends %}

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,8 @@ Changelog
 
   `PR #30 <https://github.com/adamchainz/djade/pull/30>`__.
 
+* Add spacing adjustment of top-level ``{% block %}`` and ``{% endblock %}`` tags where ``{% extends %}`` is used.
+
 * Add ``--target-version`` option to specify target Django version.
 
 * Add Django 4.2+ fixer to migrate ``{% if %}`` with ``length_is`` to use ``length`` and ```==``.

--- a/README.rst
+++ b/README.rst
@@ -236,13 +236,27 @@ Djade also implements some extra rules:
     -{% load frittata %}
     +{% load frittata omelette %}
 
-
 * Unindent ``{% extends %}`` tags:
 
   .. code-block:: diff
 
     -  {% extends 'egg.html' %}
     +{% extends 'egg.html' %}
+
+* Exactly one blank line between top-level ``{% block %}`` and ``{% endblock %}`` tags when ``{% extends %}`` is used:
+
+.. code-block:: diff
+
+     {% extends 'egg.html' %}
+
+    -
+     {% block yolk %}
+       ...
+     {% endblock yolk %}
+    +
+     {% block white %}
+       ...
+     {% endblock white %}
 
 Fixers
 ======


### PR DESCRIPTION
Fixes #3.