### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
   rev: v3.17.0
   hooks:
   - id: pyupgrade
-    args: [--py38-plus]
+    args: [--py39-plus]
 - repo: https://github.com/psf/black-pre-commit-mirror
   rev: 24.8.0
   hooks:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* Drop Python 3.8 support.
+
 * Migrate ``{% with %}`` and ``{% blocktranslate %}`` tags from the legacy ``as`` syntax to new ``=`` syntax.
 
   `Issue #82 <https://github.com/adamchainz/djade/issues/82>`__.

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Use **pip**:
 
     python -m pip install djade
 
-Python 3.8 to 3.13 supported.
+Python 3.9 to 3.13 supported.
 
 pre-commit hook
 ---------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ keywords = [
 authors = [
   { name = "Adam Johnson", email = "me@adamj.eu" },
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Framework :: Django",
@@ -22,7 +22,6 @@ classifiers = [
   "Natural Language :: English",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Now EOL: https://discuss.python.org/t/python-3-8-is-now-officially-eol/66983 .